### PR TITLE
Resetting should_loop variable

### DIFF
--- a/addons/anima/core/node.gd
+++ b/addons/anima/core/node.gd
@@ -85,8 +85,8 @@ func set_visibility_strategy(strategy: int) -> void:
 	
 func clear() -> void:
 	stop()
-
-    _should_loop = false
+	
+	_should_loop = false
 	_anima_tween.clear_animations()
 
 	_total_animation = 0.0

--- a/addons/anima/core/node.gd
+++ b/addons/anima/core/node.gd
@@ -86,14 +86,12 @@ func set_visibility_strategy(strategy: int) -> void:
 func clear() -> void:
 	stop()
 
+    _should_loop = false
 	_anima_tween.clear_animations()
 
 	_total_animation = 0.0
 	_last_animation_duration = 0.0
 	set_visibility_strategy(Anima.VISIBILITY.IGNORE)
-
-func clear_loop() -> void:
-	_should_loop = false
 
 func play() -> void:
 	_play(AnimaTween.PLAY_MODE.NORMAL)

--- a/addons/anima/core/node.gd
+++ b/addons/anima/core/node.gd
@@ -92,6 +92,9 @@ func clear() -> void:
 	_last_animation_duration = 0.0
 	set_visibility_strategy(Anima.VISIBILITY.IGNORE)
 
+func clear_loop() -> void:
+	_should_loop = false
+
 func play() -> void:
 	_play(AnimaTween.PLAY_MODE.NORMAL)
 


### PR DESCRIPTION
The `_should_loop` property never gets set to false after calling `loop()`, which causes the next animations to incorrectly keep looping, even when you only call the `play()` function.

I've created a new function `clear_loop()` that manually sets this variable to false, but I don't think this is the best approach. Maybe we could discuss a better solution in this PR?