### PR TITLE
Update anima.gd

### DIFF
--- a/addons/anima/core/anima.gd
+++ b/addons/anima/core/anima.gd
@@ -74,9 +74,9 @@ const MINIMUM_DURATION := 0.000001
 var _animations_list := []
 var _custom_animations := []
 
-func begin(node: Node, name: String = 'anima', single_shot := false):
+func begin(node: Node, name: String = 'anima', single_shot := false) -> AnimaNode:
 	var node_name = 'AnimaNode_' + name
-	var anima_node: Node
+	var anima_node: AnimaNode
 
 	for child in node.get_children():
 		if child.name.find(node_name) >= 0:


### PR DESCRIPTION
In your documentation example you seem to be using type inference:
```GDScript
var anima := Anima.begin(self)

anima.then({ node = $node, animation = "tada", duration = 0.7 })
anima.play()
```
But in your code you are not telling the compiler what type it returns which leads to the following error:
![image](https://user-images.githubusercontent.com/1850856/148530786-2a5b9d06-4e30-4a89-a865-07847e18aa4e.png)

The following pull request should fix that. Otherwise you can just change your documentation to not use type inference