### PR TITLE
Prevent having a null value on from and to property.

### DIFF
--- a/addons/anima/utils/tween_utils.gd
+++ b/addons/anima/utils/tween_utils.gd
@@ -7,6 +7,12 @@ static func calculate_from_and_to(animation_data: Dictionary, is_backwards_anima
 	var relative = animation_data.relative if animation_data.has('relative') else false
 	var current_value = AnimaNodesProperties.get_property_value(node, animation_data)
 
+	if animation_data["from"] == null:
+		animation_data.erase('from')
+
+	if animation_data["to"] == null:
+		animation_data.erase('to')
+
 	if animation_data.has('from'):
 		from = maybe_calculate_value(animation_data.from, animation_data)
 		from = _maybe_convert_from_deg_to_rad(node, animation_data, from)
@@ -36,6 +42,7 @@ static func calculate_from_and_to(animation_data: Dictionary, is_backwards_anima
 			from = from,
 			diff = { position = to.position - from.position, size = to.size - from.size }
 		}
+
 
 	return {
 		from = from,


### PR DESCRIPTION
The reason why to prevent this from is because this will give an error. This doesn't actually make sense for GDScript programmer because you don't actually had to put null on the value, but on those who is making a wrapper on other language to use this addon, this gets annoying, especially when working with relative values.